### PR TITLE
Ref issue plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = (robot) => {
   require('./lib/stale-plugin')(robot)
   require('./lib/branchlabel-plugin')(robot)
   require('./lib/addlabel-plugin')(robot)
+  require('./lib/ref-issue-plugin')(robot)
 //  require('./lib/extpr-plugin')(robot)
 //  require('./lib/update-status-plugin')(robot)
 //  require('./lib/repo-authz-plugin')(robot, path.join(__dirname, 'config', '_COMMON_', 'repo-authz'))

--- a/lib/project_id.js
+++ b/lib/project_id.js
@@ -1,0 +1,1 @@
+module.exports = {core:70,drupal:75,joomla:116,financial:47,membership:55,release:63,cloudnative:60,mailing:56,translation:7,searchandreporting:53,events:345,userinterface:338,releasecandidatetesting:179,civicrmassetplugin:429,accessibilty:79,wordpress:86}

--- a/lib/ref-issue-plugin.js
+++ b/lib/ref-issue-plugin.js
@@ -27,7 +27,7 @@ module.exports = (robot) => {
             const { Gitlab } = require('@gitbeaker/node');
             const api = new Gitlab({
                 host: 'https://lab.civicrm.org',
-                token: 'C51SPBFvuEeBsJssyQf5',
+                token: 'jjXgPeCPuRRSqHkDdy4T',
             });
             // 70 is project id for core, 1888 is issue number
             if(link_head in project_ids){

--- a/lib/ref-issue-plugin.js
+++ b/lib/ref-issue-plugin.js
@@ -1,0 +1,57 @@
+module.exports = (robot) => {
+    robot.on('pull_request.opened', async context => {
+        const pull_request = context.payload.pull_request
+        var title = pull_request.title
+        title = title.toString()
+        title = title.toLowerCase()
+        title = title.toString().split(" ").join("")
+        console.log(title)
+        if(title.slice(0,3) == 'dev'){
+            string_index=4;
+            while(string_index<title.length && title[string_index] != '#'){
+                string_index += 1;
+            }
+            var link_head = title.slice(4,string_index)
+            if(string_index == title.length){
+                return;
+            }
+            var issue_number_index = string_index+1;
+            while(issue_number_index<title.length && title[issue_number_index]-'0'>=0 && title[issue_number_index]-'0'<=9){
+                issue_number_index += 1
+            }
+            var link_number = title.slice(string_index+1,issue_number_index)
+            var ref_link = 'https://lab.civicrm.org/dev' + '/' + link_head + '/-/issues/' + link_number
+            ref_link = 'The issue assosciated with the Pull Request can be viewed on this link ' + ref_link
+
+            var project_ids = require('./project_id.js');
+            const { Gitlab } = require('@gitbeaker/node');
+            const api = new Gitlab({
+                host: 'https://lab.civicrm.org',
+                token: 'C51SPBFvuEeBsJssyQf5',
+            });
+            // 70 is project id for core, 1888 is issue number
+            if(link_head in project_ids){
+                api.Issues.show(project_ids[link_head], link_number).then((issue) => {
+                    console.log(pull_request.html_url)
+                    var string_link = 'A pull request related to this issue has been opened '
+                    string_link = string_link.link(pull_request.html_url)
+                    console.log(pull_request.title)
+                    var pull_request_link = string_link + ' with the title: ' + pull_request.title
+                    api.IssueDiscussions.create(project_ids[link_head],link_number,pull_request_link).then((comment) => {
+                        console.log(comment)
+                    }).catch(error => {
+                        console.log(error)
+                    })
+                    return context.github.issues.createComment(context.issue({body: ref_link}))
+                }). catch( error => {
+                    return context.github.issues.createComment(context.issue({body: 'Please check the issue number in the pull request title, to get correct issue link'}))
+                })
+            }
+            else{
+                return context.github.issues.createComment(context.issue({body: 'Please check the the syntax errors in pull request title, to get correct issue link'}))
+                return;
+            }
+            
+        }
+    })
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "nodemon": "^2.0.0",
     "smee-client": "^1.1.0",
     "standard": "^14.3.1"
+    "@gitbeaker/node": "^23.4.2"
   },
   "engines": {
     "node": ">= 8.3.0"


### PR DESCRIPTION
This is the main code for adding the reference issue plugin both sides on GitHub and GitLab. The ref-issue-plugin.js contains the main string hashing and is responsible for all the comments created by the bot. The project_ids.js contains GitLab project ids of different projects which are used for API requests to that project while using gitbeaker. @saurabhbatra96, In case of any queries or doubts in the code, please let me know the same :)