### PR TITLE
Docs integrate

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = (robot) => {
   require('./lib/branchlabel-plugin')(robot)
   require('./lib/addlabel-plugin')(robot)
   require('./lib/ref-issue-plugin')(robot)
+  require('./lib/docs_integrate')(robot)
 //  require('./lib/extpr-plugin')(robot)
 //  require('./lib/update-status-plugin')(robot)
 //  require('./lib/repo-authz-plugin')(robot, path.join(__dirname, 'config', '_COMMON_', 'repo-authz'))

--- a/lib/docs_integrate.js
+++ b/lib/docs_integrate.js
@@ -1,0 +1,54 @@
+
+module.exports = (robot) => {
+    robot.on('pull_request.closed', async context => {
+        const pull_request = context.payload.pull_request;
+            console.log('check')
+            const { Gitlab } = require('@gitbeaker/node');
+            const api = new Gitlab({
+                host: 'https://lab.civicrm.org',
+                token: 'C51SPBFvuEeBsJssyQf5',
+            });
+            api.MergeRequests.all(1).then((issue) => {
+                console.log(issue)
+                var pull_request_number = '#' + pull_request.number.toString()
+                for(details in issue){
+                    var issue_details = issue[details]
+                    var title = issue_details.title
+                    var equal = 1
+                    console.log(title)
+                    if(title.length<pull_request_number.length){
+                        continue
+                    }
+                    else{
+                        for(i=0;i<pull_request_number.length;i++){
+                            if(pull_request_number[i] != title[i]){
+                                equal = 0;
+                                break;
+                            }
+                        }
+                        var message_merged = 'The pull request which needed this documenatation has been merged. Thus, this documenation is also ready for merge. For more details refer here ' + pull_request.url
+                        var message_closed = 'The pull request which needed this documenatation has been closed without merging. For more details refer here ' + pull_request.url
+                        if(equal){
+                            if(pull_request.merged){
+                                api.MergeRequestDiscussions.create(1,issue_details.iid,message_merged).then((comment)=>{
+                                    console.log(comment)
+                                }).catch(error => {
+                                    console.log(error)
+                                })
+                            }
+                            else{
+                                api.MergeRequestDiscussions.create(1,issue_details.iid,message_closed).then((comment)=>{
+                                    console.log(comment)
+                                }).catch(error => {
+                                    console.log(error)
+                                })
+                            }
+                        }
+                    }
+                    
+                }
+            }).catch( error => {
+                console.log(error)
+            })
+    });
+}

--- a/lib/docs_integrate.js
+++ b/lib/docs_integrate.js
@@ -6,7 +6,7 @@ module.exports = (robot) => {
             const { Gitlab } = require('@gitbeaker/node');
             const api = new Gitlab({
                 host: 'https://lab.civicrm.org',
-                token: 'C51SPBFvuEeBsJssyQf5',
+                token: '',
             });
             api.MergeRequests.all(1).then((issue) => {
                 console.log(issue)


### PR DESCRIPTION
This pull request will add a feature to post the status of merged core PRs on their corresponding docs Merge Request. The docs merge request should be named like `#core_PR_number:xyz` for this to work. This uses GitHub pull_request_closed webhook to activate and further extracts PR details to match them with the Merge Requests on documentations project and accordingly post status. 